### PR TITLE
Update RedisProvider.ts

### DIFF
--- a/lib/provider/RedisProvider.ts
+++ b/lib/provider/RedisProvider.ts
@@ -19,7 +19,7 @@ export class RedisProvider implements CacheProvider {
 
       this.redisClient = new Redis({
         port: parsed.port,
-        host: parsed.host,
+        host: parsed.hostname,
         username: parsed.user,
         password: parsed.password,
       })


### PR DESCRIPTION
[As documented](https://github.com/vitaly-t/connection-string#virtual-properties), property `hostname` is the host name, while `host` is hostname+port.